### PR TITLE
Fix moshorssh not detecting mosh connection inside tmux

### DIFF
--- a/.github/workflows/wf_linter.yml
+++ b/.github/workflows/wf_linter.yml
@@ -35,7 +35,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
@@ -44,7 +44,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: super-linter/super-linter@v5
+        uses: super-linter/super-linter@v8
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main

--- a/.github/workflows/wf_mdlink.yml
+++ b/.github/workflows/wf_mdlink.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Check Markdown Links
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:

--- a/aliases.sh
+++ b/aliases.sh
@@ -114,9 +114,15 @@ alias ll='ls -AlFh'
 alias switch='sudo update-alternatives --config'
 
 # mosh
-moshorssh() { 
+moshorssh() {
     if env | grep -q '^SSH_CONNECTION='; then
-      if pstree -ps $$ | grep -q mosh-server; then
+      local check_pid=$$
+      if [ -n "$TMUX" ]; then
+        local client_pid
+        client_pid=$(tmux display-message -p '#{client_pid}' 2>/dev/null)
+        [ -n "$client_pid" ] && check_pid=$client_pid
+      fi
+      if pstree -ps $check_pid | grep -q mosh-server; then
         echo "Connected via mosh"
       else
         echo "Connected via ssh"

--- a/aliases.sh
+++ b/aliases.sh
@@ -122,7 +122,7 @@ moshorssh() {
         client_pid=$(tmux display-message -p '#{client_pid}' 2>/dev/null)
         [ -n "$client_pid" ] && check_pid=$client_pid
       fi
-      if pstree -ps $check_pid | grep -q mosh-server; then
+      if pstree -ps "$check_pid" | grep -q mosh-server; then
         echo "Connected via mosh"
       else
         echo "Connected via ssh"


### PR DESCRIPTION
## Summary

- Fixes #31
- When inside tmux, the tmux server daemonizes and re-parents to PID 1 (init/systemd), severing the process tree link from the current shell back to `mosh-server`
- Fix by detecting `$TMUX` and using `tmux display-message -p '#{client_pid}'` to get the tmux client PID, which is a direct child of `mosh-server` and has the correct ancestry for `pstree` traversal
- Fix shellcheck SC2086: quote `$check_pid` variable
- Upgrade GitHub Actions to latest major versions: `actions/checkout` v3→v4, `super-linter/super-linter` v5→v8

## Test plan

- [x] Connect to a remote host via mosh
- [x] Start or attach to a tmux session
- [x] Run `moshorssh` — should output `Connected via mosh`
- [x] Connect via plain SSH (no mosh) and run `moshorssh` — should output `Connected via ssh`
- [x] Run `moshorssh` outside of tmux via mosh — should still output `Connected via mosh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)